### PR TITLE
adding url unlock feature

### DIFF
--- a/imports/api/urls.js
+++ b/imports/api/urls.js
@@ -196,27 +196,31 @@ Meteor.methods({
 
   // eslint-disable-next-line meteor/audit-argument-checks
   'urls.unlock': function urlUnlock(urlId) {
+    // Calculate the threshold date for making url locks available for release.
+    const twoWeeksAgo = new Date();
+    twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
+
     const url = Urls.findOne(urlId);
-    if (url.locked !== this.userId) {
+    if ((url.locked && url.locked === this.userId) || (url.locked && Roles.userIsInRole(this.userId, 'admin', Roles.GLOBAL_GROUP) && url.lock_time <= twoWeeksAgo)) {
+      // Add a record of this lock/unlock cycle to lock_history.
+      LockHistory.insert({
+        url: urlId,
+        user: url.locked,
+        locked_at: url.lock_time,
+        unlocked_at: new Date(),
+      });
+
+      // Remove the lock.
+      Urls.update(urlId, { $set: {
+        locked: undefined,
+        lock_username: undefined,
+        lock_time: undefined,
+      } });
+
+      Meteor.users.update(url.locked, { $set: { lock_url_uuid: undefined } });
+    } else {
       throw new Meteor.Error('not-authorized');
     }
-
-    // Add a record of this lock/unlock cycle to lock_history.
-    LockHistory.insert({
-      url: urlId,
-      user: url.locked,
-      locked_at: url.lock_time,
-      unlocked_at: new Date(),
-    });
-
-    // Remove the lock.
-    Urls.update(urlId, { $set: {
-      locked: undefined,
-      lock_username: undefined,
-      lock_time: undefined,
-    } });
-
-    Meteor.users.update(url.locked, { $set: { lock_url_uuid: undefined } });
   },
 
   // eslint-disable-next-line meteor/audit-argument-checks

--- a/imports/selectors/url.js
+++ b/imports/selectors/url.js
@@ -1,3 +1,13 @@
+
+// locks that have been checked for longer than two weeks are considered stale
+export function lockIsStale(url = {}) {
+  // Calculate the threshold date for making url locks available for release.
+  const twoWeeksAgo = new Date();
+  twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
+
+  return (url.lock_time <= twoWeeksAgo);
+}
+
 export function formatMetadataJSON(url, user = {}) {
   // const agency = Agencies.get(url.agency);
   // return url;

--- a/imports/ui/components/UrlLock.js
+++ b/imports/ui/components/UrlLock.js
@@ -1,9 +1,10 @@
 import React from 'react';
 
+import { lockIsStale } from '../../selectors/url';
+
 const UrlLock = ({ currentUser, admin, url, handleLock, handleUnlock }) => {
-  // Calculate the threshold date for making url locks available for release.
-  const twoWeeksAgo = new Date();
-  twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
+  // check for a stale lock (if locked)
+  const stale = lockIsStale(url);
 
   // Evaluate URL status.
   const status = url.locked ? `Checked out by ${url.lock_username} at ${url.lock_time.toString()}` : 'Not checked out';
@@ -19,10 +20,10 @@ const UrlLock = ({ currentUser, admin, url, handleLock, handleUnlock }) => {
   } else if (currentUser && url.locked && (currentUser._id === url.locked)) {
     // Users are allowed to release urls they checked out themselves.
     actions = <button className="btn btn-primary" onClick={handleUnlock}>Checkin this URL</button>;
-  } else if (currentUser && url.locked && admin && url.lock_time <= twoWeeksAgo) {
+  } else if (currentUser && url.locked && admin && stale) {
     // Admin users can release URLs that have been locked for two weeks.
-    actions = <button className="btn btn-primary" onClick={handleUnlock}>Checkin this URL</button>;
-  } else if (currentUser && url.locked && admin && url.lock_time > twoWeeksAgo) {
+    actions = <button className="btn btn-warning" onClick={handleUnlock}>Force-Checkin this URL</button>;
+  } else if (currentUser && url.locked && admin && !stale) {
     actions = <i>This URL has been checked out for less than two weeks.</i>;
   }
 

--- a/imports/ui/components/UrlLock.js
+++ b/imports/ui/components/UrlLock.js
@@ -1,0 +1,38 @@
+import React from 'react';
+
+const UrlLock = ({ currentUser, admin, url, handleLock, handleUnlock }) => {
+  // Calculate the threshold date for making url locks available for release.
+  const twoWeeksAgo = new Date();
+  twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
+
+  // Evaluate URL status.
+  const status = url.locked ? `Checked out by ${url.lock_username} at ${url.lock_time.toString()}` : 'Not checked out';
+
+  // Present appropriate URL actions for the given situation.
+  let actions;
+  if (!currentUser && !url.locked) {
+    // Nudge the user to sign in and get to work.
+    actions = <i>sign in to check out this url</i>;
+  } else if (currentUser && !url.locked) {
+    // If the user is signed in and the url is not locked, it's fair game.
+    actions = <button className="btn btn-primary" onClick={handleLock}>Checkout this URL</button>;
+  } else if (currentUser && url.locked && (currentUser._id === url.locked)) {
+    // Users are allowed to release urls they checked out themselves.
+    actions = <button className="btn btn-primary" onClick={handleUnlock}>Checkin this URL</button>;
+  } else if (currentUser && url.locked && admin && url.lock_time <= twoWeeksAgo) {
+    // Admin users can release URLs that have been locked for two weeks.
+    actions = <button className="btn btn-primary" onClick={handleUnlock}>Checkin this URL</button>;
+  } else if (currentUser && url.locked && admin && url.lock_time > twoWeeksAgo) {
+    actions = <i>This URL has been checked out for less than two weeks.</i>;
+  }
+
+  const urlLock = (
+    <div className="url-lock">
+      <div className="url-lock__status">URL Status: {status}</div>
+      <div className="url-lock__actions">{actions}</div>
+    </div>
+  );
+  return urlLock;
+};
+
+export default UrlLock;

--- a/imports/ui/containers/pages/UrlEdit.js
+++ b/imports/ui/containers/pages/UrlEdit.js
@@ -15,6 +15,7 @@ import { status, phaseNum } from '../../../selectors/url';
 
 import Spinner from '../../components/Spinner';
 import Modal from '../../components/Modal';
+import UrlLock from '../../components/UrlLock';
 import UrlForm from '../../components/form/UrlForm';
 
 import UrlPhaseResearch from '../../components/form/UrlPhaseResearch';
@@ -217,18 +218,6 @@ class Url extends React.Component {
     );
   }
 
-  renderLock(url) {
-    if (!this.props.currentUser) {
-      return <i>sign in to checkout this url</i>;
-    }
-    if (!url.locked) {
-      return <button className="btn btn-primary" onClick={this.handleLock.bind(this)}>Checkout this URL</button>;
-    } else if (this.props.currentUser._id === url.locked) {
-      return <button className="btn btn-primary" onClick={this.handleUnlock.bind(this)}>Checkin this URL</button>;
-    }
-    return '';
-  }
-
   renderContributors() {
     let bullets;
     if (!this.state.collapse.contributors) {
@@ -311,8 +300,7 @@ class Url extends React.Component {
               <h4 className="subtitle">{url.uuid}</h4>
               <h5>status: <span className={`status-${phase}-text`}>{phase}</span></h5>
               <hr />
-              {url.locked ? <div><h4>In Use</h4><p>Checked out by {url.lock_username} at {url.lock_time.toString() } </p></div> : undefined }
-              {this.renderLock(url)}
+              <UrlLock currentUser={currentUser} admin={admin} url={url} handleLock={this.handleLock.bind(this)} handleUnlock={this.handleUnlock.bind(this)} />
               <hr />
               <h4>Info</h4>
             </div>


### PR DESCRIPTION
Addresses https://github.com/edgi-govdata-archiving/archivers.space/issues/32

This change allows admin users to check URLs back in after they've been checked out for two weeks. It's not a cron job, but it's a start.

I'm trying to figure out how best to encapsulate control logic in this framework. On the UI end, I've pulled all of the logic for the URLs page into a UrlLock component. This gives us a single point of reference for answering the two UI questions: what state is this URL in? and what can the current user do about it?

But to impose the "check in by admins after two weeks" logic, I've had to duplicate the date check: once in the urls api object, to enforce the rule, and once in the UI component to determine whether to give the user the option to unlock. This redundancy seems wrong to me. When we change the rule to allow check-in after, say, one week, I hate the idea of hunting for the same logic throughout the code and changing it in multiple places.

I think there should either be an independent utility that accepts a URL and calculates whether it's unlockable, or there should be an "I am expired?" calculator attached to all URL objects.

Thoughts?