### PR TITLE
Bump url limit above 30 and deploy

### DIFF
--- a/imports/ui/containers/pages/UrlList.js
+++ b/imports/ui/containers/pages/UrlList.js
@@ -102,7 +102,7 @@ export default createContainer(({ location }) => {
   const query = Session.get('urls.query') || q;
   if (query) {
     Meteor.subscribe('urls', page * pageSize);
-    urls = Urls.find({ $or: [{ url: new RegExp(`.*${query}.*`, 'i') }, { uuid: new RegExp(`.*${query}.*`, 'i') }] }, { limit: 30 }).fetch();
+    urls = Urls.find({ $or: [{ url: new RegExp(`.*${query}.*`, 'i') }, { uuid: new RegExp(`.*${query}.*`, 'i') }] }, { limit: 1000 }).fetch();
   } else {
     subscription = (phase === '') ? 'urls' : `urls.${phase}`;
     selector = phaseSelector(phase);


### PR DESCRIPTION
In Toronto, @dcwalk and I have been filtering on "epa.gov" in order to understand how many urls we have left. but I just realized it's capped at 30 urls: https://github.com/edgi-govdata-archiving/archivers.space/tree/master/imports/ui/containers/pages/UrlList.js#L105

@b5 any reason I couldn't bump that and redeploy? :slightly_smiling_face:

cc: @mattprice who was rightfully suspicious of the url count :wink: